### PR TITLE
configmap/secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 hs_err_pid*
 replay_pid*
 
-*.env
+*.env*
 backup/
 data/
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Private minecraft server "denkettle" configuration.
   ```
 
   ```shell
-  kubectl exec 
+  kubectl exec -it $CONTAINER_NAME -- /bin/bash
   ```
 
 ### RCON Commands

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Private minecraft server "denkettle" configuration.
 - Set secret variables.
 
   ```shell
-  cat <<EOF > .env.secret
+  cat <<EOF > secret.env
   CONTAINER_NAME=hoge
   LOCAL_DNS=hogehoge
   SERVER_HOST_NAME=huga
@@ -58,7 +58,7 @@ Private minecraft server "denkettle" configuration.
 
   ```shell
   source .env
-  source .env.secret
+  source secret.env
   ```
 
 ### Make a ConfigMap in Kubernetes

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Private minecraft server "denkettle" configuration.
   docker compose up -d
   ```
 
-- Stop  docker compose down
+- Stop Docker container:
 
   ```shell
   docker compose down

--- a/README.md
+++ b/README.md
@@ -6,47 +6,59 @@ Private minecraft server "denkettle" configuration.
 
 ## .env file
 
-```shell
-cat <<EOF > .env
-PASSWD=hoge
-LOCAL_DNS=hogehoge
-SERVER_HOST_NAME=huga
-CONTAINER_NAME=hoge
-VERSION=latest
-EULA=TRUE
-ENABLE_ROLLING_LOGS=TRUE
-VERSION=${VERSION}
-TYPE="PAPER"
-DIFFICULTY="hard"
-LEVEL="world"
-MOTD="✋(◉ ω ◉｀)よお"
-MAX_PLAYERS=30
-MAX_WORLD_SIZE=12000
-ENABLE_RCON=TRUE
-RCON_PASSWORD=${PASSWD}
-ENABLE_COMMAND_BLOCK=TRUE
-FORCE_WORLD_COPY=TRUE
-SNOOPER_ENABLED=FALSE
-VIEW_DISTANCE=50
-SIMULATION_DISTANCE=100
-GAMEMODE="survival"
-PVP=TRUE
-ANNOUNCE_PLAYER_ACHIEVEMENTS=TRUE
-OVERRIDE_ICON=TRUE
-ENABLE_WHITELIST=TRUE
-MAX_THREADS=6
-INIT_MEMORY=8G
-MAX_MEMORY=16G
-SERVER_PORT="25565"
-JVM_OPTS="-XX:MaxRAMPercentage=95 -Xms8192M -Xmx16384M -XX:+AlwaysPreTouch -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:MaxInlineLevel=15"
-PAPER_CHANNEL="experimental"
-EOF
-```
+- Set environment variables.
+
+  ```shell
+  cat <<EOF > .env
+  CONTAINER_NAME=hoge
+  LOCAL_DNS=hogehoge
+  SERVER_HOST_NAME=huga
+  RCON_PASSWORD=hoge
+  VERSION=latest
+  EULA=TRUE
+  ENABLE_ROLLING_LOGS=TRUE
+  TYPE="PAPER"
+  DIFFICULTY="hard"
+  LEVEL="world"
+  MOTD="✋(◉ ω ◉｀)よお"
+  MAX_PLAYERS=30
+  MAX_WORLD_SIZE=12000
+  ENABLE_RCON=TRUE
+  ENABLE_COMMAND_BLOCK=TRUE
+  FORCE_WORLD_COPY=TRUE
+  SNOOPER_ENABLED=FALSE
+  VIEW_DISTANCE=50
+  SIMULATION_DISTANCE=100
+  GAMEMODE="survival"
+  PVP=TRUE
+  ANNOUNCE_PLAYER_ACHIEVEMENTS=TRUE
+  OVERRIDE_ICON=TRUE
+  ENABLE_WHITELIST=TRUE
+  MAX_THREADS=6
+  INIT_MEMORY=8G
+  MAX_MEMORY=16G
+  SERVER_PORT="25565"
+  JVM_OPTS="-XX:MaxRAMPercentage=95 -Xms8192M -Xmx16384M -XX:+AlwaysPreTouch -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:MaxInlineLevel=15"
+  PAPER_CHANNEL="experimental"
+  EOF
+  ```
+
+- Set secret variables.
+
+  ```shell
+  cat <<EOF > .env.secret
+  CONTAINER_NAME=hoge
+  LOCAL_DNS=hogehoge
+  SERVER_HOST_NAME=huga
+  RCON_PASSWORD=hoge
+  EOF
+  ```
 
 - Run `source` command.
 
   ```shell
   source .env
+  source .env.secret
   ```
 
 ### Make a ConfigMap in Kubernetes

--- a/README.md
+++ b/README.md
@@ -10,17 +10,13 @@ Private minecraft server "denkettle" configuration.
 
   ```shell
   cat <<EOF > .env
-  CONTAINER_NAME=hoge
-  LOCAL_DNS=hogehoge
-  SERVER_HOST_NAME=huga
-  RCON_PASSWORD=hoge
   VERSION=latest
   EULA=TRUE
   ENABLE_ROLLING_LOGS=TRUE
-  TYPE="PAPER"
-  DIFFICULTY="hard"
-  LEVEL="world"
-  MOTD="✋(◉ ω ◉｀)よお"
+  TYPE=PAPER
+  DIFFICULTY=hard
+  LEVEL=world
+  MOTD=✋(◉ ω ◉｀)よお
   MAX_PLAYERS=30
   MAX_WORLD_SIZE=12000
   ENABLE_RCON=TRUE
@@ -29,7 +25,7 @@ Private minecraft server "denkettle" configuration.
   SNOOPER_ENABLED=FALSE
   VIEW_DISTANCE=50
   SIMULATION_DISTANCE=100
-  GAMEMODE="survival"
+  GAMEMODE=survival
   PVP=TRUE
   ANNOUNCE_PLAYER_ACHIEVEMENTS=TRUE
   OVERRIDE_ICON=TRUE
@@ -37,9 +33,9 @@ Private minecraft server "denkettle" configuration.
   MAX_THREADS=6
   INIT_MEMORY=8G
   MAX_MEMORY=16G
-  SERVER_PORT="25565"
-  JVM_OPTS="-XX:MaxRAMPercentage=95 -Xms8192M -Xmx16384M -XX:+AlwaysPreTouch -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:MaxInlineLevel=15"
-  PAPER_CHANNEL="experimental"
+  SERVER_PORT=25565
+  JVM_OPTS=-XX:MaxRAMPercentage=95 -Xms8192M -Xmx16384M -XX:+AlwaysPreTouch -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:MaxInlineLevel=15
+  PAPER_CHANNEL=experimental
   EOF
   ```
 
@@ -54,54 +50,66 @@ Private minecraft server "denkettle" configuration.
   EOF
   ```
 
-- Run `source` command.
-
-  ```shell
-  source .env
-  source secret.env
-  ```
-
-### Make a ConfigMap in Kubernetes
+### Make a ConfigMap and Secret
 
 - Run the following command.
 
-```shell
-kubectl create configmap minecraft-server-config --from-env-file=.env
-```
-
-- Confirm the ConfigMap.
-
   ```shell
-  kubectl get configmap minecraft-server-config
+  sudo chmod +x gensecret.sh
   ```
-  
-  - Result
-  
-    ```shell
-    NAME                      DATA   AGE
-    minecraft-server-config   5      7s
-    ```
 
-- If you want to delete the ConfigMap, run the following command.
+- Create a ConfigMap.
 
   ```shell
-  kubectl delete configmap minecraft-server-config
+  ./gensecret.sh .env ConfigMap
+  ConfigMap created in manifests/k8s-configmap.yaml
+  ```
+
+- Create a Secret.
+
+  ```shell
+  ./gensecret.sh secret.env Secret
+  Secret created in manifests/k8s-secret.yaml
   ```
 
 ## Commands
 
-- Docker compose up
+### Docker
+
+- Run Docker container.
 
   ```shell
   docker compose up -d
   ```
 
-## RCON Commands
+- Stop  docker compose down
 
-- Run Docker commands
+  ```shell
+  docker compose down
+  ```
+
+### Kubernetes 
+
+  ```shell
+  kubectl apply -f manifests
+  ```
+
+  ```shell
+  kubectl exec 
+  ```
+
+### RCON Commands
+
+- Docker exec
 
   ```shell
   docker exec -i $CONTAINER_NAME rcon-cli
+  ```
+
+- Kubectl exec
+
+  ```shell
+  kubectl exec -it $CONTAINER_NAME rcon-cli
   ```
 
 - RCON commands
@@ -123,7 +131,8 @@ kubectl create configmap minecraft-server-config --from-env-file=.env
     enchant <target> <enchant name> [<count>]
     ```
 
-    - unbreaking, mending
+    - unbreaking
+    - mending
 
 ## Plugin Server
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -42,6 +42,8 @@ services:
     image: itzg/mc-backup
     depends_on:
       - mc-vanilla
+    env_file:
+      - .env
     environment:
       TZ: Asia/Tokyo
       BACKUP_NAME: "${CONTAINER_NAME}-backup"

--- a/gensecret.sh
+++ b/gensecret.sh
@@ -31,9 +31,13 @@ echo "apiVersion: v1
 kind: $KIND
 metadata:
   name: $FILE_NAME
-  namespace: $NAMESPACE
-type: Opaque
-data:" > manifests/$FILE_NAME.yaml
+  namespace: $NAMESPACE" > manifests/$FILE_NAME.yaml
+
+if [[ "$KIND" == "Secret" ]]; then
+  echo "type: Opaque" >> manifests/$FILE_NAME.yaml
+fi
+
+echo "data:" >> manifests/$FILE_NAME.yaml
 
 while IFS='=' read -r key value || [[ -n "$key" ]]; do
   [[ "$key" == \#* || -z "$key" ]] && continue

--- a/gensecret.sh
+++ b/gensecret.sh
@@ -1,20 +1,50 @@
 #!/bin/bash
-ENV_FILE=".env"
-SECRET_NAME="denkettle-secret"
+ENV_FILE="$1"
+KIND="$2"
 NAMESPACE="default"
+FILE_NAME="k8s-$(echo "$KIND" | tr '[:upper:]' '[:lower:]')"
+
+if [[ -z "$ENV_FILE" ]]; then
+  echo "No environment file provided."
+  echo "Usage: $0 <env_file> <kind>"
+  exit 1
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Error: File '$ENV_FILE' does not exist."
+  exit 1
+fi
+
+if [[ -z "$KIND" ]]; then
+  echo "No kind provided. Defaulting to 'Secret'."
+  echo "Usage: $0 <env_file> <kind>"
+  exit 1
+fi
+
+if [[ "$KIND" != "ConfigMap" && "$KIND" != "Secret" ]]; then
+  echo "Error: Invalid kind '$KIND'."
+  echo "Usage: $0 <env_file> <kind>"
+  exit 1
+fi
 
 echo "apiVersion: v1
-kind: Secret
+kind: $KIND
 metadata:
-  name: $SECRET_NAME
+  name: $FILE_NAME
   namespace: $NAMESPACE
 type: Opaque
-data:" > manifests/$SECRET_NAME.yaml
+data:" > manifests/$FILE_NAME.yaml
 
 while IFS='=' read -r key value || [[ -n "$key" ]]; do
   [[ "$key" == \#* || -z "$key" ]] && continue
-  encoded_value=$(echo -n "$value" | base64)
-  echo "  $key: $encoded_value" >> manifests/$SECRET_NAME.yaml
+  if [[ "$KIND" == "ConfigMap" ]]; then
+    encoded_value=$(echo -n "$value" | sed 's/"/\\"/g')  # Escape quotes for ConfigMap
+  fi
+  if [[ "$KIND" == "Secret" ]]; then
+    encoded_value=$(echo -n "$value" | base64)  # Encode value for Secret
+  fi
+  echo "  $key: '$encoded_value'" >> manifests/$FILE_NAME.yaml
 done < "$ENV_FILE"
 
-echo "Secret created in manifests/$SECRET_NAME.yaml"
+echo "$KIND created in manifests/$FILE_NAME.yaml"
+exit 0

--- a/manifests/denkettle-k8s.yaml
+++ b/manifests/denkettle-k8s.yaml
@@ -41,7 +41,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 8Gi
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/manifests/k8s-configmap.yaml
+++ b/manifests/k8s-configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-configmap
+  namespace: default
+type: Opaque
+data:
+  VERSION: 'latest'
+  EULA: 'TRUE'
+  ENABLE_ROLLING_LOGS: 'TRUE'
+  TYPE: 'PAPER'
+  DIFFICULTY: 'hard'
+  LEVEL: 'world'
+  MOTD: '✋(◉ ω ◉｀)よお'
+  MAX_PLAYERS: '30'
+  MAX_WORLD_SIZE: '12000'
+  ENABLE_RCON: 'TRUE'
+  ENABLE_COMMAND_BLOCK: 'TRUE'
+  FORCE_WORLD_COPY: 'TRUE'
+  SNOOPER_ENABLED: 'FALSE'
+  VIEW_DISTANCE: '50'
+  SIMULATION_DISTANCE: '100'
+  GAMEMODE: 'survival'
+  PVP: 'TRUE'
+  ANNOUNCE_PLAYER_ACHIEVEMENTS: 'TRUE'
+  OVERRIDE_ICON: 'TRUE'
+  ENABLE_WHITELIST: 'TRUE'
+  MAX_THREADS: '6'
+  INIT_MEMORY: '8G'
+  MAX_MEMORY: '16G'
+  SERVER_PORT: '25565'
+  JVM_OPTS: '-XX:MaxRAMPercentage=95 -Xms8192M -Xmx16384M -XX:+AlwaysPreTouch -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:MaxInlineLevel=15'
+  PAPER_CHANNEL: 'experimental'

--- a/manifests/k8s-configmap.yaml
+++ b/manifests/k8s-configmap.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: k8s-configmap
   namespace: default
-type: Opaque
 data:
   VERSION: 'latest'
   EULA: 'TRUE'

--- a/manifests/k8s-secret.yaml
+++ b/manifests/k8s-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8s-secret
+  namespace: default
+type: Opaque
+data:
+  CONTAINER_NAME: 'aG9nZQ=='
+  LOCAL_DNS: 'aG9nZWhvZ2U='
+  SERVER_HOST_NAME: 'aHVnYQ=='
+  RCON_PASSWORD: 'aG9nZQ=='


### PR DESCRIPTION
This pull request updates the configuration for a private Minecraft server, focusing on improving environment variable management and adding support for secret variables. The changes enhance clarity and organization in the setup process.

### Environment variable management:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-L26): Updated `.env` file example to include `CONTAINER_NAME` and `RCON_PASSWORD` directly, removed redundant variables, and added a note to set environment variables.
* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR45-R46): Added support for an `.env` file in the `mc-backup` service to streamline environment variable usage.

### Secret variable management:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R61): Introduced a new `secret.env` file for sensitive variables (`CONTAINER_NAME`, `LOCAL_DNS`, `SERVER_HOST_NAME`, `RCON_PASSWORD`) and updated instructions to source it alongside `.env`.