### PR TITLE
networking.yamlを更新し、MinecraftサービスをNodePortに変更。内部サービスの設定を整理し、Ingress設定…

### DIFF
--- a/manifests/networking.yaml
+++ b/manifests/networking.yaml
@@ -1,6 +1,29 @@
 ---
 # Minecraft Service for Tailscale VPN access
-# Internal service for pod-to-pod communication
+# NodePort service for direct external access via Tailscale VPN
+apiVersion: v1
+kind: Service
+metadata:
+  name: denkettle-minecraft
+  labels:
+    app: denkettle
+spec:
+  type: NodePort
+  selector:
+    app: denkettle
+  ports:
+    - name: minecraft-tcp
+      port: 25565
+      targetPort: 25565
+      protocol: TCP
+      nodePort: 30565  # Fixed external port for Minecraft
+    - name: rcon
+      port: 25575
+      targetPort: 25575
+      protocol: TCP
+      nodePort: 30575  # Fixed external port for RCON
+---
+# Internal ClusterIP service for pod-to-pod communication
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,23 +43,3 @@ spec:
       port: 25575
       targetPort: 25575
       protocol: TCP
----
-# Ingress for external access
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: denkettle-external
-  labels:
-    app: denkettle
-spec:
-  rules:
-    - host: 192.168.49.2 # Replace with your minikube IP
-      http:
-        paths:
-          - pathType: Prefix
-            path: /
-            backend:
-              service:
-                name: denkettle-internal
-                port:
-                  number: 25565


### PR DESCRIPTION

This pull request updates the Kubernetes service configuration for the `denkettle` application to improve external access and clarify the roles of internal and external services. The most important changes include switching the Minecraft service to a `NodePort` type for external access and reconfiguring the internal service to use `ClusterIP`.

### Networking configuration updates:

* Updated the `denkettle-minecraft` service to use `NodePort` for direct external access via Tailscale VPN, including fixed external ports for Minecraft (30565) and RCON (30575).
* Renamed the `denkettle-internal` service to `denkettle-minecraft` and changed its type from `ClusterIP` to `NodePort` to reflect its new purpose.
* Reintroduced an internal `ClusterIP` service named `denkettle-internal` for pod-to-pod communication, separating internal and external traffic responsibilities.
* Removed the ingress configuration for external access, as it is no longer needed with the `NodePort` service.