### PR TITLE
Clean up README.md for unsafe-end-portal-teleportation settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,8 @@ Private minecraft server "denkettle" configuration.
   unsupported-settings:
     allow-headless-pistons: true # <- change here
     allow-permanent-block-break-exploits: false
-    allow-unsafe-end-portal-teleportation: true # <- change here
     allow-piston-duplication: true # <- change here
-    allow-unsafe-end-portal-teleportation:  true # <- change here
+    allow-unsafe-end-portal-teleportation: true # <- change here
     compression-format: ZLIB
     perform-username-validation: true
     skip-tripwire-hook-placement-validation: true # <- change here
@@ -217,4 +216,3 @@ Private minecraft server "denkettle" configuration.
     update-equipment-on-player-actions: true
   ~~~
   ```
-

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,15 +31,14 @@ services:
           memory: 16.0G
     command: >
       sh -c "
-      sed -i 's/allow-headless-pistons: false/allow-headless-pistons: true/' /data/config/paper-global.yml
-      sed -i 's/allow-piston-duplication: false/allow-piston-duplication: true/' /data/config/paper-global.yml
-      sed -i 's/allow-unsafe-end-portal-teleportation: false/allow-unsafe-end-portal-teleportation: true/' /data/config/paper-global.yml
-      sed -i 's/max-entity-collisions: 8/max-entity-collisions: 16/' /data/config/paper-global.yml
-      sed -i 's/skip-tripwire-hook-placement-validation: false/skip-tripwire-hook-placement-validation: true/' /data/config/paper-global.yml
-      cat /data/config/paper-global.yml
       /start &
       SERVER_PID=$$!
       sleep 30
+      sed -i 's/allow-headless-pistons: false/allow-headless-pistons: true/' /data/config/paper-global.yml
+      sed -i 's/allow-piston-duplication: false/allow-piston-duplication: true/' /data/config/paper-global.yml
+      sed -i 's/allow-unsafe-end-portal-teleportation: false/allow-unsafe-end-portal-teleportation: true/' /data/config/paper-global.yml
+      sed -i 's/skip-tripwire-hook-placement-validation: false/skip-tripwire-hook-placement-validation: true/' /data/config/paper-global.yml
+      cat /data/config/paper-global.yml
       wait $$SERVER_PID
       "
 


### PR DESCRIPTION
Organize the lines related to unsafe-end-portal-teleportation in the README.md and remove unnecessary comments.